### PR TITLE
Dep updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ RUN mvn -f /usr/src/app/pom.xml clean package
 
 # Package
 #FROM tomcat:9.0-jdk21-corretto-al2
-FROM tomcat:9.0-jdk21-corretto-al2
-RUN yum -y install shadow-utils
+FROM tomcat:10.1.50-jre21-temurin-noble
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 
 ## set up structured logging for tomcat
 ARG ECS_LOGGING_VERSION=1.2.0
@@ -21,7 +21,7 @@ COPY --from=build /usr/src/app/target/sr-manager*.war /usr/local/tomcat/webapps/
 COPY src/main/webapp/WEB-INF/app.conf /etc/standard-reports/app.conf
 COPY ./scripts /usr/local/bin
 
-RUN adduser -u 1012 app \
+RUN adduser --uid 1012 --disabled-password --gecos "" app \
   && chown -R app /usr/local/tomcat /etc/standard-reports
 USER app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build
-FROM maven:3.6-jdk-8 AS build  
+FROM maven:3.9.12-amazoncorretto-21-debian AS build
 COPY src /usr/src/app/src  
 COPY pom.xml /usr/src/app  
 RUN mvn -f /usr/src/app/pom.xml clean package

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ Reports manager for constructing batch reports.
 
 Implements both report submission/status tracking web service and backend report processor.
 
+## Changelog
+
+| Date | Version | Changes |
+|---|---|---|
+| 2026-01-06 | 0.2.1 | Dependency updates to java 21, tomcat 10, jersey 3 |
+| Prior to 2025-09-15 | 0.1.3 | Production deployed version |
+
 ## Endpoints provided
 
 ### Report processing

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Should have:
 1501k - 1750k  2
 1751k - 2000k  7
 
-Rerunning this in 2025 (presumably after data bacfilled) those values are:
+Rerunning this in 2025 (presumably after data backfilled) those values are:
 
 1001k - 1250k  1
 1251k - 1500k  2

--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,6 @@
       <logback-json.version>6.6</logback-json.version>
         <tomcat-version>10.1.50</tomcat-version>
       <armlib.version>1.0.0</armlib.version>
-      <appbase.version>4.0.0</appbase.version>
-      <lib.version>4.0.0</lib.version>
       <sapi.version>4.0.0</sapi.version>
       <jersey.version>3.1.11</jersey.version>
     </properties>
@@ -92,40 +90,10 @@
       <version>${sapi.version}</version>
     </dependency>
 
-      <!--
-    <dependency>
-      <groupId>com.epimorphics</groupId>
-      <artifactId>lib</artifactId>
-      <version>3.1.4</version>
-    </dependency>
-
-    <dependency>
-      <groupId>com.epimorphics</groupId>
-      <artifactId>appbase</artifactId>
-      <version>3.1.11</version>
-      <exclusions>
-        <exclusion>
-          <artifactId>slf4j-log4j12</artifactId>
-          <groupId>org.slf4j</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>log4j</artifactId>
-          <groupId>log4j</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-  -->
-
     <dependency>
       <groupId>com.epimorphics</groupId>
       <artifactId>armlib</artifactId>
       <version>${armlib.version}</version>
-      <exclusions>
-        <exclusion>
-          <artifactId>log4j</artifactId>
-          <groupId>log4j</groupId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -13,13 +13,18 @@
     <tag>HEAD</tag>
   </scm>
 
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <micrometer.version>1.7.5</micrometer.version>
-    <logback.version>1.3.16</logback.version>
-    <logback-json.version>6.6</logback-json.version>
-    <tomcat-version>9.0.110</tomcat-version>
-  </properties>
+    <properties>
+      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+      <micrometer.version>1.7.5</micrometer.version>
+      <logback.version>1.3.16</logback.version>
+      <logback-json.version>6.6</logback-json.version>
+        <tomcat-version>9.0.110</tomcat-version>
+      <armlib.version>1.0.0</armlib.version>
+      <appbase.version>4.0.0</appbase.version>
+      <lib.version>4.0.0</lib.version>
+      <sapi.version>4.0.0</sapi.version>
+      <jersey.version>3.1.11</jersey.version>
+    </properties>
 
   <repositories>
     <repository>
@@ -84,9 +89,10 @@
     <dependency>
       <groupId>com.epimorphics</groupId>
       <artifactId>sapi-lib</artifactId>
-      <version>2.2.0</version>
+      <version>${sapi.version}</version>
     </dependency>
 
+      <!--
     <dependency>
       <groupId>com.epimorphics</groupId>
       <artifactId>lib</artifactId>
@@ -108,11 +114,12 @@
         </exclusion>
       </exclusions>
     </dependency>
-  
+  -->
+
     <dependency>
       <groupId>com.epimorphics</groupId>
       <artifactId>armlib</artifactId>
-      <version>0.4.0</version>
+      <version>${armlib.version}</version>
       <exclusions>
         <exclusion>
           <artifactId>log4j</artifactId>
@@ -136,10 +143,10 @@
     </dependency>
 
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>3.1.0</version>
-      <scope>provided</scope>
+        <groupId>jakarta.servlet</groupId>
+        <artifactId>jakarta.servlet-api</artifactId>
+        <version>6.0.0</version>
+        <scope>provided</scope>
     </dependency>
 
     <dependency>
@@ -166,7 +173,7 @@
         <groupId>org.glassfish.jersey.containers</groupId>
         <!-- if your container implements Servlet API older than 3.0, use "jersey-container-servlet-core"  -->
         <artifactId>jersey-container-servlet</artifactId>
-        <version>2.25.1</version>
+        <version>${jersey.version}</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.epimorphics</groupId>
   <artifactId>sr-manager</artifactId>
-  <version>0.1.3</version>
+  <version>0.2.0</version>
   <packaging>war</packaging>
   <name>sr-manager</name>
   <description>Standard Reports Manager</description>
@@ -18,7 +18,7 @@
       <micrometer.version>1.7.5</micrometer.version>
       <logback.version>1.3.16</logback.version>
       <logback-json.version>6.6</logback-json.version>
-        <tomcat-version>9.0.110</tomcat-version>
+        <tomcat-version>10.1.50</tomcat-version>
       <armlib.version>1.0.0</armlib.version>
       <appbase.version>4.0.0</appbase.version>
       <lib.version>4.0.0</lib.version>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.epimorphics</groupId>
   <artifactId>sr-manager</artifactId>
-  <version>0.2.0</version>
+  <version>0.2.1</version>
   <packaging>war</packaging>
   <name>sr-manager</name>
   <description>Standard Reports Manager</description>

--- a/pom.xml
+++ b/pom.xml
@@ -220,10 +220,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
+        <version>3.14.1</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>21</source>
+          <target>21</target>
         </configuration>
       </plugin>
 
@@ -236,11 +236,6 @@
         </configuration>
       </plugin>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-release-plugin</artifactId>
-        <version>2.3.2</version>
-      </plugin>
     </plugins>
 
     <extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -16,9 +16,9 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <micrometer.version>1.7.5</micrometer.version>
-    <logback.version>1.3.15</logback.version>
+    <logback.version>1.3.16</logback.version>
     <logback-json.version>6.6</logback-json.version>
-    <tomcat-version>9.0.108</tomcat-version>
+    <tomcat-version>9.0.110</tomcat-version>
   </properties>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
       <logback.version>1.3.16</logback.version>
       <logback-json.version>6.6</logback-json.version>
         <tomcat-version>10.1.50</tomcat-version>
-      <armlib.version>1.0.0</armlib.version>
+      <armlib.version>1.0.1</armlib.version>
       <sapi.version>4.0.0</sapi.version>
       <jersey.version>3.1.11</jersey.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -217,21 +217,27 @@
         <groupId>org.springframework.build</groupId>
         <artifactId>aws-maven</artifactId>
         <version>5.0.0.RELEASE</version>
-      <!-- 
-        <groupId>org.springframework.build.aws</groupId>  
-        <artifactId>org.springframework.build.aws.maven</artifactId>  
-        <version>3.0.0.RELEASE</version>          
-      -->
       </extension>
     </extensions>
 
   </build>
-  
-  <distributionManagement>
-    <repository>
-      <id>epi-public-repo</id>
-      <url>ftp://epimorphics.com</url>
-    </repository>
-  </distributionManagement>
+
+    <distributionManagement>
+        <repository>
+            <id>epi-public-s3-release</id>
+            <name>Epimorphics S3 release repository</name>
+            <url>s3://epi-repository/release</url>
+            <releases><enabled>true</enabled></releases>
+            <snapshots><enabled>false</enabled></snapshots>
+        </repository>
+
+        <snapshotRepository>
+            <id>epi-public-s3-snapshot</id>
+            <name>Epimorphics S3 snapshot repository</name>
+            <url>s3://epi-repository/snapshot</url>
+            <releases><enabled>false</enabled></releases>
+            <snapshots><enabled>true</enabled></snapshots>
+        </snapshotRepository>
+    </distributionManagement>
 
 </project>

--- a/src/main/java/com/epimorphics/standardReports/ReportManager.java
+++ b/src/main/java/com/epimorphics/standardReports/ReportManager.java
@@ -15,6 +15,8 @@ import static com.epimorphics.standardReports.Constants.TEST_PARAM;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.concurrent.TimeUnit;
 
 import com.epimorphics.appbase.core.Shutdown;
@@ -28,7 +30,6 @@ import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import org.apache.jena.query.ResultSet;
-import org.apache.jena.util.FileManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -186,9 +187,8 @@ public class ReportManager extends ComponentBase implements Startup, Shutdown {
         return srQueryFactory.get(templateName);
     }
 
-    public String getRawQuery(String templateName) {
-        return FileManager.get().readWholeFileAsUTF8(
-                new File(templateDir, templateName).getPath());
+    public String getRawQuery(String templateName) throws IOException  {
+        return Files.readString(new File(templateDir, templateName).toPath());
     }
 
     public class RequestProcessor implements Runnable {

--- a/src/main/java/com/epimorphics/standardReports/SRQuery.java
+++ b/src/main/java/com/epimorphics/standardReports/SRQuery.java
@@ -13,7 +13,7 @@ import static com.epimorphics.standardReports.Constants.*;
 
 import java.util.regex.Matcher;
 
-import javax.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.MultivaluedMap;
 
 import org.apache.jena.shared.PrefixMapping;
 import org.apache.jena.vocabulary.XSD;

--- a/src/main/java/com/epimorphics/standardReports/SRQueryFactory.java
+++ b/src/main/java/com/epimorphics/standardReports/SRQueryFactory.java
@@ -10,11 +10,12 @@
 package com.epimorphics.standardReports;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.jena.shared.PrefixMapping;
-import org.apache.jena.util.FileManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,9 +55,9 @@ public class SRQueryFactory {
     public String getRaw(String templateName) {
         String template = rawQueries.get(templateName);
         if (template == null) {
-            String fname = new File(templateDir, templateName).getPath();
+            Path fname = new File(templateDir, templateName).toPath();
             try {
-                template = FileManager.get().readWholeFileAsUTF8( fname );
+                template = Files.readString(fname);
                 rawQueries.put(templateName, template);
             } catch (Exception e) {
                 log.error("Could not locate template: " + templateName);

--- a/src/main/java/com/epimorphics/standardReports/aggregators/Accumulator.java
+++ b/src/main/java/com/epimorphics/standardReports/aggregators/Accumulator.java
@@ -11,6 +11,7 @@ package com.epimorphics.standardReports.aggregators;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.math.RoundingMode;
 
 import org.apache.jena.query.QuerySolution;
 
@@ -89,7 +90,7 @@ public class Accumulator implements Aggregator {
         if (count == 0) {
             return new BigDecimal(0);
         } else {
-            return total.divide( new BigDecimal(count), scale, BigDecimal.ROUND_HALF_DOWN );
+            return total.divide( new BigDecimal(count), scale, RoundingMode.HALF_DOWN );
         }
     }
     

--- a/src/main/java/com/epimorphics/standardReports/aggregators/AveragePriceAggregator.java
+++ b/src/main/java/com/epimorphics/standardReports/aggregators/AveragePriceAggregator.java
@@ -11,7 +11,7 @@ package com.epimorphics.standardReports.aggregators;
 
 import java.util.List;
 
-import javax.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.MultivaluedMap;
 
 import org.apache.jena.query.QuerySolution;
 

--- a/src/main/java/com/epimorphics/standardReports/aggregators/BandedPriceAggregator.java
+++ b/src/main/java/com/epimorphics/standardReports/aggregators/BandedPriceAggregator.java
@@ -11,7 +11,7 @@ package com.epimorphics.standardReports.aggregators;
 
 import java.util.List;
 
-import javax.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.MultivaluedMap;
 
 import org.apache.jena.query.QuerySolution;
 

--- a/src/main/java/com/epimorphics/standardReports/aggregators/BaseAggregator.java
+++ b/src/main/java/com/epimorphics/standardReports/aggregators/BaseAggregator.java
@@ -23,7 +23,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-import javax.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.MultivaluedMap;
 
 public abstract class BaseAggregator implements SRAggregator {
     protected int row_len;      // Length of sheet rows

--- a/src/main/java/com/epimorphics/standardReports/aggregators/CSVOutput.java
+++ b/src/main/java/com/epimorphics/standardReports/aggregators/CSVOutput.java
@@ -15,7 +15,7 @@ import java.io.OutputStreamWriter;
 
 import com.epimorphics.util.EpiException;
 
-import au.com.bytecode.opencsv.CSVWriter;
+import com.opencsv.CSVWriter;
 
 /**
  * Support for writing standard reports out as CSV files.

--- a/src/main/java/com/epimorphics/standardReports/aggregators/SExcelWriter.java
+++ b/src/main/java/com/epimorphics/standardReports/aggregators/SExcelWriter.java
@@ -171,7 +171,7 @@ public class SExcelWriter implements SheetWriter {
     public void write(OutputStream out) throws IOException {
         wb.write(out);
         out.close();
-        wb.dispose();
+        // wb.dispose(); // This is now deprecated and clean up is all done within wb.close
         wb.close();
     }
     

--- a/src/main/java/com/epimorphics/standardReports/aggregators/SRAggregator.java
+++ b/src/main/java/com/epimorphics/standardReports/aggregators/SRAggregator.java
@@ -12,7 +12,7 @@ package com.epimorphics.standardReports.aggregators;
 import java.io.IOException;
 import java.io.OutputStream;
 
-import javax.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.MultivaluedMap;
 
 public interface SRAggregator extends Aggregator {
 

--- a/src/main/java/com/epimorphics/standardReports/webapi/LatestMonthAvailable.java
+++ b/src/main/java/com/epimorphics/standardReports/webapi/LatestMonthAvailable.java
@@ -13,10 +13,10 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/com/epimorphics/standardReports/webapi/LogRequestFilter.java
+++ b/src/main/java/com/epimorphics/standardReports/webapi/LogRequestFilter.java
@@ -11,7 +11,7 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.core.Response.Status;
+import jakarta.ws.rs.core.Response.Status;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/com/epimorphics/standardReports/webapi/LogRequestFilter.java
+++ b/src/main/java/com/epimorphics/standardReports/webapi/LogRequestFilter.java
@@ -3,14 +3,14 @@ package com.epimorphics.standardReports.webapi;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicLong;
 
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.ws.rs.core.Response.Status;
 
 import org.slf4j.Logger;

--- a/src/main/java/com/epimorphics/standardReports/webapi/ReportEndpoint.java
+++ b/src/main/java/com/epimorphics/standardReports/webapi/ReportEndpoint.java
@@ -11,11 +11,11 @@ package com.epimorphics.standardReports.webapi;
 
 import java.io.InputStream;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
 
 @Path("report")
 public class ReportEndpoint extends SREndpointBase {

--- a/src/main/java/com/epimorphics/standardReports/webapi/ReportRequestEndpoint.java
+++ b/src/main/java/com/epimorphics/standardReports/webapi/ReportRequestEndpoint.java
@@ -17,15 +17,15 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
 
 import org.apache.jena.atlas.json.JsonObject;
 import org.slf4j.Logger;

--- a/src/main/java/com/epimorphics/standardReports/webapi/SystemEndpoint.java
+++ b/src/main/java/com/epimorphics/standardReports/webapi/SystemEndpoint.java
@@ -9,11 +9,11 @@
 
 package com.epimorphics.standardReports.webapi;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Response;
 
 import com.epimorphics.armlib.CacheManager;
 import com.epimorphics.armlib.QueueManager;

--- a/src/test/java/com/epimorphics/standardReports/aggregators/TestAggregators.java
+++ b/src/test/java/com/epimorphics/standardReports/aggregators/TestAggregators.java
@@ -11,24 +11,22 @@ package com.epimorphics.standardReports.aggregators;
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.ByteArrayOutputStream;
-import java.io.FileOutputStream;
-import java.io.FileReader;
-import java.io.IOException;
+import java.io.*;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.file.Files;
 
+import com.opencsv.exceptions.CsvValidationException;
 import jakarta.ws.rs.core.MultivaluedMap;
 
 import org.apache.jena.query.QuerySolution;
 import org.apache.jena.query.QuerySolutionMap;
 import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.ResourceFactory;
-import org.apache.jena.util.FileManager;
 import org.glassfish.jersey.internal.util.collection.MultivaluedStringMap;
 import org.junit.Test;
 
-import au.com.bytecode.opencsv.CSVReader;
+import com.opencsv.CSVReader;
 
 public class TestAggregators {
 
@@ -105,8 +103,8 @@ public class TestAggregators {
         
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         apa.writeAsCSV(out, request);
-        
-        String expected = FileManager.get().readWholeFileAsUTF8("src/test/data/testAPV.csv");
+
+        String expected = Files.readString(new File("src/test/data/testAPV.csv").toPath());
         assertEquals(expected, filterCreatedMetadata( out.toString() ));
         
         // Testing Excel output is correct is tricky (and currently manual) but at least this checks it runs
@@ -115,7 +113,7 @@ public class TestAggregators {
     }
     
     @Test
-    public void testBandedAggregator() throws IOException {
+    public void testBandedAggregator() throws IOException, CsvValidationException {
         BandedPriceAggregator bpa = new BandedPriceAggregator();
         
         // Replay a canned test query
@@ -148,8 +146,8 @@ public class TestAggregators {
         
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         bpa.writeAsCSV(out, request);
-        
-        String expected = FileManager.get().readWholeFileAsUTF8("src/test/data/devon-banded-agg.csv");
+
+        String expected = Files.readString(new File("src/test/data/devon-banded-agg.csv").toPath());
 //        System.out.println("TEMP:\n" + filterCreatedMetadata( out.toString() ));
         assertEquals(expected, filterCreatedMetadata( out.toString() ));
         

--- a/src/test/java/com/epimorphics/standardReports/aggregators/TestAggregators.java
+++ b/src/test/java/com/epimorphics/standardReports/aggregators/TestAggregators.java
@@ -18,7 +18,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
-import javax.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.MultivaluedMap;
 
 import org.apache.jena.query.QuerySolution;
 import org.apache.jena.query.QuerySolutionMap;

--- a/src/test/java/com/epimorphics/standardReports/query/TestQueryGeneration.java
+++ b/src/test/java/com/epimorphics/standardReports/query/TestQueryGeneration.java
@@ -6,7 +6,7 @@ import org.apache.jena.shared.impl.PrefixMappingImpl;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 
-import javax.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedHashMap;
 
 import static com.epimorphics.standardReports.Constants.*;
 


### PR DESCRIPTION
Update appbase/sapi stack to 4.0.0 release to remove outdated dependencies.

Update tomcat to version 10.1.50 (necessary for new sapi due to move of servlet API to jakarta namespace).

Update runner base image to debian (tomcat 10.* images not available under Corretto/AL2).

Bump armlib to fix content-encoding issue introduced by armlib SDK update.